### PR TITLE
Various fixes and features

### DIFF
--- a/Lexico.Test/XunitTrace.cs
+++ b/Lexico.Test/XunitTrace.cs
@@ -2,7 +2,7 @@ using Xunit.Abstractions;
 
 namespace Lexico.Test
 {
-    internal sealed class XunitTrace : TextTrace
+    public sealed class XunitTrace : TextTrace
     {
         private readonly ITestOutputHelper _outputHelper;
 

--- a/Lexico/Alternative.cs
+++ b/Lexico/Alternative.cs
@@ -49,10 +49,11 @@ namespace Lexico
             OutputType = baseType;
             if (optionTypes != null)
             {
-                foreach (var type in optionTypes)
-                {
-                    if (!baseType.IsAssignableFrom(type)) throw new ArgumentException($"Option '{type}' is not assignable to base type '{baseType}'");
-                }
+                if (baseType != typeof(Unnamed))
+                    foreach (var type in optionTypes)
+                    {
+                        if (!baseType.IsAssignableFrom(type)) throw new ArgumentException($"Option '{type}' is not assignable to base type '{baseType}'");
+                    }
             }
             else
             {

--- a/Lexico/EOF.cs
+++ b/Lexico/EOF.cs
@@ -41,4 +41,37 @@ namespace Lexico
             context.Succeed(Empty());
         }
     }
+
+    public class SOFAttribute : TermAttribute
+    {
+        public override int Priority => 110;
+        public override IParser Create(MemberInfo member, ChildParser child, IConfig config)
+        {
+            if (member == typeof(SOF)) {
+                return SOFParser.Instance;
+            }
+            return new SurroundParser(null, child(null), SOFParser.Instance);
+        }
+    }
+
+    /// <summary>
+    /// Only matches the start-of-file (i.e. expects the Position to be at 0). No output
+    /// </summary>
+    [SOF] public struct SOF {}
+
+    internal class SOFParser : IParser
+    {
+        public static SOFParser Instance { get; } = new SOFParser();
+        private SOFParser() {}
+
+        public override string ToString() => "SOF";
+
+        public Type OutputType => typeof(void);
+
+        public void Compile(ICompileContext context)
+        {
+            context.Append(IfThen(GreaterThan(context.Position, Constant(0)), Goto(context.Failure)));
+            context.Succeed(Empty());
+        }
+    } 
 }

--- a/Lexico/EOL.cs
+++ b/Lexico/EOL.cs
@@ -32,9 +32,13 @@ namespace Lexico
             var breakTarget = Label();
             var fail = Goto(context.Failure);
             var succeed = Goto(breakTarget);
+            context.Append(IfThen(GreaterThanOrEqual(context.Position, context.Length), succeed));
             context.Append(Switch(context.Peek(0), fail,
                 SwitchCase(Block(AddAssign(context.Position, Constant(1)), succeed), Constant('\n')),
-                SwitchCase(IfThenElse(Equal(context.Peek(1), Constant('\n')),
+                SwitchCase(IfThenElse(And(
+                        LessThan(Add(Constant(1), context.Position), context.Length),
+                        Equal(context.Peek(1), Constant('\n'))
+                    ),
                     Block(AddAssign(context.Position, Constant(2)), succeed),
                     fail), Constant('\r'))
             ));

--- a/Lexico/ICompileContext.cs
+++ b/Lexico/ICompileContext.cs
@@ -12,11 +12,12 @@ namespace Lexico
         Expression Position { get; }
         Expression? Result { get; }
         Expression Length { get; }
+        Expression? Cut { get; }
         Expression Cache(Expression value);
         Expression String { get; }
         Expression UserObject { get; }
         void Append(Expression statement);
-        void Child(IParser child, string? name, Expression? result, LabelTarget? onSuccess, LabelTarget onFail);
+        void Child(IParser child, string? name, Expression? result, LabelTarget? onSuccess, LabelTarget onFail, Expression? cut = null);
         void Recursive(IParser child);
     }
 

--- a/Lexico/ICompileContext.cs
+++ b/Lexico/ICompileContext.cs
@@ -6,6 +6,7 @@ namespace Lexico
     public interface ICompileContext
     {
         LabelTarget Save();
+        void Release(LabelTarget target);
         void Restore(LabelTarget savePoint);
         LabelTarget? Success { get; }
         LabelTarget Failure { get; }
@@ -14,6 +15,7 @@ namespace Lexico
         Expression Length { get; }
         Expression? Cut { get; }
         Expression Cache(Expression value);
+        void Release(Expression variable);
         Expression String { get; }
         Expression UserObject { get; }
         void Append(Expression statement);

--- a/Lexico/Lexico.cs
+++ b/Lexico/Lexico.cs
@@ -8,6 +8,9 @@ namespace Lexico
     /// </summary>
     public static class Lexico
     {
+
+        public static int Stack = 0;
+
         /// <summary>
         /// Parses a value of the given Type (T) from an input string.
         /// Throws a FormatException if the parsing fails.

--- a/Lexico/Lexico.cs
+++ b/Lexico/Lexico.cs
@@ -8,9 +8,6 @@ namespace Lexico
     /// </summary>
     public static class Lexico
     {
-
-        public static int Stack = 0;
-
         /// <summary>
         /// Parses a value of the given Type (T) from an input string.
         /// Throws a FormatException if the parsing fails.

--- a/Lexico/Literal.cs
+++ b/Lexico/Literal.cs
@@ -12,7 +12,7 @@ namespace Lexico
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | Class | Struct, AllowMultiple = false)]
     public abstract class TerminalAttribute : TermAttribute
     {
-        public override int Priority => 30;
+        public override int Priority => 10;
         public abstract IParser Create(MemberInfo member, IConfig config);
 
         public override IParser Create(MemberInfo member, ChildParser child, IConfig config)
@@ -48,9 +48,12 @@ namespace Lexico
         public string Property { get; }
 
         public override IParser Create(MemberInfo member, IConfig config) {
-            var prop = member.ReflectedType.GetProperty(Property, Instance | Public | NonPublic)
-                ?? throw new ArgumentException($"Could not find `{Property}` on {member.ReflectedType}");
-            return new LiteralParser((string)prop.GetValue(Activator.CreateInstance(member.ReflectedType, true)));
+            if (ReflectedType == null) {
+                throw new Exception("'Indirect' attributes must be applied to a class member");
+            }
+            var prop = ReflectedType.GetProperty(Property, Instance | Public | NonPublic)
+                ?? throw new ArgumentException($"Could not find `{Property}` on {ReflectedType}");
+            return new LiteralParser((string)prop.GetValue(Activator.CreateInstance(ReflectedType, true)));
         }
     }
 

--- a/Lexico/LookAhead.cs
+++ b/Lexico/LookAhead.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+
+namespace Lexico
+{
+    public class LookAheadAttribute : TermAttribute
+    {
+        public override int Priority => 100;
+
+        public override IParser Create(MemberInfo member, ChildParser child, IConfig config)
+        {
+            return new LookAheadParser(child(null));
+        }
+    }
+
+    public class LookAheadParser : IParser
+    {
+        public LookAheadParser(IParser inner) => this.inner = inner;
+        private readonly IParser inner;
+        public Type OutputType => typeof(void);
+
+        public void Compile(ICompileContext context)
+        {
+            var savePoint = context.Save();
+            context.Child(inner, null, context.Result, savePoint, context.Failure);
+            context.Restore(savePoint);
+            context.Succeed();
+        }
+    }
+}

--- a/Lexico/LookAhead.cs
+++ b/Lexico/LookAhead.cs
@@ -25,6 +25,7 @@ namespace Lexico
             context.Child(inner, null, context.Result, savePoint, context.Failure);
             context.Restore(savePoint);
             context.Succeed();
+            context.Release(savePoint);
         }
     }
 }

--- a/Lexico/Not.cs
+++ b/Lexico/Not.cs
@@ -26,6 +26,7 @@ namespace Lexico
             context.Child(inner, null, context.Result, context.Failure, savePoint);
             context.Restore(savePoint);
             context.Succeed();
+            context.Release(savePoint);
         }
     }
 }

--- a/Lexico/Number.cs
+++ b/Lexico/Number.cs
@@ -105,6 +105,7 @@ namespace Lexico
             var match = context.Cache(Default(typeof(string)));
             context.Child(regex, null, match, null, context.Failure);
             context.Succeed(Call(parseMethod, match, Constant(styles)));
+            context.Release(match);
         }
 
         public override string ToString() => $"Number ({OutputType.Name})";

--- a/Lexico/Optional.cs
+++ b/Lexico/Optional.cs
@@ -57,6 +57,7 @@ namespace Lexico
                 context.Append(Label(skip));
             }
             context.Succeed();
+            context.Release(savePoint);
         }
 
         public override string ToString() => $"{child}?";

--- a/Lexico/ParserCache.cs
+++ b/Lexico/ParserCache.cs
@@ -15,6 +15,8 @@ namespace Lexico
     [AttributeUsage(Field | Property | Class | Struct, AllowMultiple = true)]
     public class TermAttribute : Attribute
     {
+        public Type? ReflectedType { get; set; }
+
         /// <summary>
         /// Determines the order that parsers are generated in. Higher priority attributes are evaluated first,
         /// and therefore applied last in the chain.
@@ -119,6 +121,9 @@ namespace Lexico
         {
             var defaults = new Queue<TermAttribute>(defaultAttrs);
             var attrs = new Queue<TermAttribute>(member.GetCustomAttributes<TermAttribute>(true).OrderByDescending(a => a.Priority));
+            foreach (var a in attrs) {
+                a.ReflectedType = member.ReflectedType;
+            }
             var mConfig = GetConfig(member) ?? Config.Default;
             IParser Next(MemberInfo? child) {
                 if (child != null) {
@@ -127,6 +132,7 @@ namespace Lexico
                         // TODO: If this is not true, it is possible for recursion to not work properly
                     }
                     foreach (var attr in child.GetCustomAttributes<TermAttribute>(true).OrderByDescending(a => a.Priority)) {
+                        attr.ReflectedType = child.ReflectedType;
                         attrs.Enqueue(attr);
                     }
                     member = child;

--- a/Lexico/Pass.cs
+++ b/Lexico/Pass.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Reflection;
+
+namespace Lexico
+{
+    public class PassAttribute : TerminalAttribute
+    {
+        public override IParser Create(MemberInfo member, IConfig config)
+        {
+            return Pass.Instance;
+        }
+    }
+
+    internal class Pass : IParser
+    {
+        public static IParser Instance { get; } = new Pass();
+        public Type OutputType => typeof(void);
+
+        public void Compile(ICompileContext context)
+        {
+            context.Succeed();
+        }
+    }
+}

--- a/Lexico/RegexImpl.cs
+++ b/Lexico/RegexImpl.cs
@@ -45,6 +45,7 @@ namespace Lexico.RegexImpl
             var start = context.Cache(context.Position);
             context.Child(inner, null, null, null, context.Failure);
             context.Succeed(Call(context.String, nameof(string.Substring), Type.EmptyTypes, start, Subtract(context.Position, start)));
+            context.Release(start);
         }
     }
 
@@ -87,6 +88,7 @@ namespace Lexico.RegexImpl
             {
                 context.Succeed();
             }
+            context.Release(sb);
         }
 
         public override string ToString() => "Regex sequence";

--- a/Lexico/Repeat.cs
+++ b/Lexico/Repeat.cs
@@ -131,6 +131,7 @@ namespace Lexico
             context.Append(Goto(loop));
             context.Restore(loopFail);
             context.Append(Label(loopEnd));
+            context.Release(loopFail);
 
             // Loop ends; decide whether to succeed or not
             if (Min.HasValue) {
@@ -141,6 +142,9 @@ namespace Lexico
             } else {
                 context.Succeed(list ?? Empty());
             }
+            context.Release(list);
+            context.Release(output);
+            context.Release(count);
         }
 
         public override string ToString() => $"[{Element}...]";

--- a/Lexico/Repeat.cs
+++ b/Lexico/Repeat.cs
@@ -31,7 +31,7 @@ namespace Lexico
 
         public override IParser Create(MemberInfo member, ChildParser child, IConfig config)
         {
-            var listType = member.GetMemberType();
+            var listType = member.GetMemberType() ?? throw new ArgumentException();
             var elementType = listType switch {
                 {} when listType == typeof(string) => typeof(char),
                 {IsArray: true} => listType.GetElementType(),

--- a/Lexico/SeparatedBy.cs
+++ b/Lexico/SeparatedBy.cs
@@ -10,6 +10,8 @@ namespace Lexico
     [AttributeUsage(Field | Property | Class | Struct, AllowMultiple = false)]
     public class SeparatedByAttribute : TermAttribute
     {
+        public override int Priority => 25;
+
         public SeparatedByAttribute(Type separator) {
             separatorType = separator ?? throw new ArgumentNullException(nameof(separator));
         }

--- a/Lexico/SeparatedBy.cs
+++ b/Lexico/SeparatedBy.cs
@@ -33,7 +33,7 @@ namespace Lexico
             var sep = GetSeparator(config);
             return c switch {
                 RepeatParser r => new RepeatParser(r.OutputType, r.Element, sep, r.Min, r.Max),
-                SequenceParser s => new SequenceParser(s.Type, sep),
+                SequenceParser s => new SequenceParser(s.Type, sep, s.CheckZeroLength),
                 _ => throw new ArgumentException($"Separator not valid on {c}")
             };
         }

--- a/Lexico/Sequence.cs
+++ b/Lexico/Sequence.cs
@@ -117,6 +117,8 @@ namespace Lexico
                 context.Append(IfThen(LessThanOrEqual(context.Position, currentPos), Goto(context.Failure)));
             }
             context.Succeed(obj!);
+            context.Release(currentPos);
+            context.Release(obj);
         }
 
         private static bool IsPrivate(MemberInfo member) => member switch

--- a/Lexico/Sequence.cs
+++ b/Lexico/Sequence.cs
@@ -16,15 +16,18 @@ namespace Lexico
     {
         public override int Priority => 0;
         public override IParser Create(MemberInfo member, ChildParser child, IConfig config)
-            => new SequenceParser(member.GetMemberType(), null);
+            => new SequenceParser(member.GetMemberType(), null, CheckZeroLength);
 
         public override bool AddDefault(MemberInfo member) => member is Type;
+
+        public bool CheckZeroLength { get; set; }
     }
 
     internal class SequenceParser : IParser
     {
-        public SequenceParser(Type type, IParser? separator)
+        public SequenceParser(Type type, IParser? separator, bool checkZeroLength)
         {
+            this.CheckZeroLength = checkZeroLength;
             this.Type = type ?? throw new ArgumentNullException(nameof(type));
             this.separator = separator;
             var typeHierachy = new List<Type>();
@@ -72,6 +75,7 @@ namespace Lexico
         }
 
         public Type Type { get; }
+        public bool CheckZeroLength { get; }
         private readonly (MemberInfo? member, IParser parser)[] members;
         private readonly IParser? separator;
 
@@ -79,6 +83,10 @@ namespace Lexico
 
         public void Compile(ICompileContext context)
         {
+            Expression currentPos = null!;
+            if (CheckZeroLength) {
+                currentPos = context.Cache(context.Position);
+            }
             // Get the current value. If it's not the right type, make a new one.
             // If we're not saving the value, no need to do this
             Expression? obj = null;
@@ -104,6 +112,9 @@ namespace Lexico
                 context.Child(parser, member?.Name,
                     member == null || obj == null ? null : MakeMemberAccess(obj, member),
                     null, context.Failure);
+            }
+            if (CheckZeroLength) {
+                context.Append(IfThen(LessThanOrEqual(context.Position, currentPos), Goto(context.Failure)));
             }
             context.Succeed(obj!);
         }

--- a/Lexico/Trace.cs
+++ b/Lexico/Trace.cs
@@ -75,7 +75,7 @@ namespace Lexico
                         if (lastPush.Value.name != null) {
                             sb.Append(lastPush.Value.name).Append(" : ");
                         }
-                        sb.Append(lastPush.Value.parser?.ToString() ?? "<UNKNOWN>").Append(' ');
+                        sb.Append((lastPush.Value.parser?.ToString() ?? "<UNKNOWN>").Replace("\n", "\\n").Replace("\r", "\\r")).Append(' ');
                         lastPush = null;
                     } else {
                         currentIndent--;
@@ -88,7 +88,7 @@ namespace Lexico
                         if (text.String != null && text.Length == 0 && text.Start < text.String.Length) {
                             text = new StringSegment(text.String, text.Start, text.Length + 1);
                         }
-                        sb.Append("\u2717 (got `").Append(text).Append("`)");
+                        sb.Append("\u2717 (got `").Append(text.ToString().Replace("\n", "\\n")).Append("`)");
                     }
                     break;
                 case false:
@@ -153,7 +153,7 @@ namespace Lexico
                     if (name != null) {
                         sb.Append(name).Append(" : ");
                     }
-                    sb.Append(parser?.ToString() ?? "<UNKNOWN>").Append(" {");
+                    sb.Append((parser?.ToString() ?? "<UNKNOWN>").Replace("\n", "\\n").Replace("\r", "\\r")).Append(" {");
                     break;
                 case false:
                     var parserString = parser?.ToString() ?? "<UNKNOWN>";

--- a/Lexico/Trace.cs
+++ b/Lexico/Trace.cs
@@ -88,7 +88,7 @@ namespace Lexico
                         if (text.String != null && text.Length == 0 && text.Start < text.String.Length) {
                             text = new StringSegment(text.String, text.Start, text.Length + 1);
                         }
-                        sb.Append("\u2717 (got `").Append(text.ToString().Replace("\n", "\\n")).Append("`)");
+                        sb.Append("\u2717 (got `").Append(text.ToString().Replace("\n", "\\n").Replace("\r", "\\r")).Append("`)");
                     }
                     break;
                 case false:


### PR DESCRIPTION
- Add look-ahead
- Add negative look-ahead
- Both of those included in regex
- Fix SeparatedBy priority so it's ahead of Repeat (i.e. `[WhitespaceSeparated] List<int>` will now work as expected)
- Added CheckZeroLength to sequence: optionally fail a sequence if nothing was matched within it
- Fix folding in verbose trace
- Add Cut (NB, still needs unit tests)
- Optimize the compile context to re-use local variables